### PR TITLE
feat: Add TraversableFold and Folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Overview
 
-This crate provides traits and proc macros to implement the visitor pattern for arbitrary data structures. This pattern is particularly useful when dealing with complex nested data structures, abstract trees and hierarchies of all kinds.
+This crate provides traits and proc macros to implement visitor and folder patterns for arbitrary data structures. These patterns are particularly useful when dealing with complex nested data structures, abstract trees and hierarchies of all kinds.
 
 ## Quick Start
 
@@ -87,12 +87,49 @@ fn main() {
 }
 ```
 
+Use `TraversableFold` for owned bottom-up rewrites:
+
+```rust
+use std::ops::ControlFlow;
+
+use traversable::TraversableFold;
+use traversable::function::folder_leave;
+
+#[derive(TraversableFold)]
+enum Expr {
+    Add(Box<Expr>, Box<Expr>),
+    Literal(i32),
+}
+
+fn simplify(expr: Expr) -> Expr {
+    match expr {
+        Expr::Add(left, right) => match (*left, *right) {
+            (Expr::Literal(0), expr) | (expr, Expr::Literal(0)) => expr,
+            (left, right) => Expr::Add(Box::new(left), Box::new(right)),
+        },
+        expr => expr,
+    }
+}
+
+fn main() {
+    let expr = Expr::Add(Box::new(Expr::Literal(0)), Box::new(Expr::Literal(1)));
+    let mut folder = folder_leave::<Expr, (), _>(|expr| ControlFlow::Continue(simplify(expr)));
+
+    let expr = match expr.traverse_fold(&mut folder) {
+        ControlFlow::Continue(expr) => expr,
+        ControlFlow::Break(()) => unreachable!(),
+    };
+
+    assert!(matches!(expr, Expr::Literal(1)));
+}
+```
+
 ## Attributes
 
 The derive macro supports the following attributes on structs and enums:
 
-*   `#[traverse(skip_self)]`: Skips calling the visitor for the annotated type while still traversing its children.
-*   `#[traverse(skip_children)]`: Calls the visitor for the annotated type without traversing its children.
+*   `#[traverse(skip_self)]`: Skips calling the visitor or folder for the annotated type while still traversing its children.
+*   `#[traverse(skip_children)]`: Calls the visitor or folder for the annotated type without traversing its children.
 
 The derive macro supports the following attributes on fields and variants:
 

--- a/traversable-derive/Cargo.toml
+++ b/traversable-derive/Cargo.toml
@@ -16,7 +16,7 @@
 name = "traversable-derive"
 version = "0.2.0"
 
-description = "Procedural macro to derive Traversable and TraversableMut"
+description = "Procedural macro to derive Traversable, TraversableMut, and TraversableFold"
 documentation = "https://docs.rs/traversable-derive"
 keywords = ["visitor", "traverse", "traversable"]
 readme = "README.md"

--- a/traversable-derive/README.md
+++ b/traversable-derive/README.md
@@ -20,4 +20,5 @@ This is an implementation crate for the [`traversable`](https://crates.io/crates
 
 Please refer to the main [`traversable`](https://crates.io/crates/traversable) crate for documentation and usage examples.
 
-This crate contains procedural macros that derive `Traversable` and `TraversableMut` implementations.
+This crate contains procedural macros that derive `Traversable`, `TraversableMut`, and
+`TraversableFold` implementations.

--- a/traversable-derive/src/lib.rs
+++ b/traversable-derive/src/lib.rs
@@ -55,6 +55,11 @@ pub fn derive_traversable_mut(input: proc_macro::TokenStream) -> proc_macro::Tok
     expand_with(input, |stream| impl_traversable(stream, true))
 }
 
+#[proc_macro_derive(TraversableFold, attributes(traverse))]
+pub fn derive_traversable_fold(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    expand_with(input, impl_traversable_fold)
+}
+
 fn expand_with(
     input: proc_macro::TokenStream,
     handler: impl Fn(DeriveInput) -> Result<TokenStream>,
@@ -438,6 +443,223 @@ fn traverse_field(value: &TokenStream, field: Field, mutable: bool) -> Result<To
             let traverse_fn = traverse_fn.string_literal()?.parse::<Path>()?;
             Ok(quote! {
                 #traverse_fn(#value, visitor)?;
+            })
+        }
+    }
+}
+
+fn impl_traversable_fold(input: DeriveInput) -> Result<TokenStream> {
+    let mut params = Params::from_attrs(input.attrs, "traverse")?;
+    params.validate(&["skip_self", "skip_children"])?;
+
+    let skip_visit_self = params
+        .param("skip_self")?
+        .map(Param::unit)
+        .transpose()?
+        .is_some();
+    let skip_children = params
+        .param("skip_children")?
+        .map(Param::unit)
+        .transpose()?
+        .is_some();
+
+    let name = input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let crate_name = resolve_crate_name();
+
+    let enter_self = if skip_visit_self {
+        quote! {
+            let this = self;
+        }
+    } else {
+        quote! {
+            let this = #crate_name::Folder::enter(folder, self)?;
+        }
+    };
+
+    let fold_children = match input.data {
+        Data::Struct(struct_) => {
+            if skip_children {
+                Ok(TokenStream::new())
+            } else {
+                fold_struct(struct_)
+            }
+        }
+        Data::Enum(enum_) => {
+            if skip_children {
+                Ok(TokenStream::new())
+            } else {
+                fold_enum(enum_)
+            }
+        }
+        Data::Union(union_) => {
+            return Err(Error::new_spanned(
+                union_.union_token,
+                "unions are not supported",
+            ));
+        }
+    }?;
+
+    let leave_self = if skip_visit_self {
+        TokenStream::new()
+    } else {
+        quote! {
+            let this = #crate_name::Folder::leave(folder, this)?;
+        }
+    };
+
+    Ok(quote! {
+        impl #impl_generics #crate_name::TraversableFold for #name #ty_generics #where_clause {
+            fn traverse_fold<V: #crate_name::Folder>(
+                self,
+                folder: &mut V
+            ) -> ::core::ops::ControlFlow<V::Break, Self> {
+                #enter_self
+                #fold_children
+                #leave_self
+                ::core::ops::ControlFlow::Continue(this)
+            }
+        }
+    })
+}
+
+fn fold_struct(s: DataStruct) -> Result<TokenStream> {
+    Ok(match s.fields {
+        Fields::Named(fields) => {
+            let mut field_names = Vec::new();
+            let mut fold_fields = Vec::new();
+
+            for field in fields.named {
+                let field_name = field.ident.clone().unwrap();
+                fold_fields.push(fold_field(&field_name.to_token_stream(), field)?);
+                field_names.push(field_name);
+            }
+
+            quote! {
+                let this = match this {
+                    Self { #( #field_names ),* } => {
+                        #( #fold_fields )*
+                        Self { #( #field_names ),* }
+                    }
+                };
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let mut field_names = Vec::new();
+            let mut fold_fields = Vec::new();
+
+            for (index, field) in fields.unnamed.into_iter().enumerate() {
+                let field_name = Ident::new(&format!("i{index}"), Span::call_site());
+                fold_fields.push(fold_field(&field_name.to_token_stream(), field)?);
+                field_names.push(field_name);
+            }
+
+            quote! {
+                let this = match this {
+                    Self( #( #field_names ),* ) => {
+                        #( #fold_fields )*
+                        Self( #( #field_names ),* )
+                    }
+                };
+            }
+        }
+        Fields::Unit => TokenStream::new(),
+    })
+}
+
+fn fold_enum(e: DataEnum) -> Result<TokenStream> {
+    let variants = e
+        .variants
+        .into_iter()
+        .map(fold_variant)
+        .collect::<Result<TokenStream>>()?;
+    Ok(quote! {
+        let this = match this {
+            #variants
+        };
+    })
+}
+
+fn fold_variant(v: Variant) -> Result<TokenStream> {
+    let mut params = Params::from_attrs(v.attrs, "traverse")?;
+    params.validate(&["skip"])?;
+    let skip = params
+        .param("skip")?
+        .map(Param::unit)
+        .transpose()?
+        .is_some();
+
+    let name = v.ident;
+    Ok(match v.fields {
+        Fields::Named(fields) => {
+            let mut field_names = Vec::new();
+            let mut fold_fields = Vec::new();
+
+            for field in fields.named {
+                let field_name = field.ident.clone().unwrap();
+                if !skip {
+                    fold_fields.push(fold_field(&field_name.to_token_stream(), field)?);
+                }
+                field_names.push(field_name);
+            }
+
+            quote! {
+                Self::#name { #( #field_names ),* } => {
+                    #( #fold_fields )*
+                    Self::#name { #( #field_names ),* }
+                }
+            }
+        }
+        Fields::Unnamed(fields) => {
+            let mut field_names = Vec::new();
+            let mut fold_fields = Vec::new();
+
+            for (index, field) in fields.unnamed.into_iter().enumerate() {
+                let field_name = Ident::new(&format!("i{index}"), Span::call_site());
+                if !skip {
+                    fold_fields.push(fold_field(&field_name.to_token_stream(), field)?);
+                }
+                field_names.push(field_name);
+            }
+
+            quote! {
+                Self::#name( #( #field_names ),* ) => {
+                    #( #fold_fields )*
+                    Self::#name( #( #field_names ),* )
+                }
+            }
+        }
+        Fields::Unit => {
+            quote! {
+                Self::#name => Self::#name
+            }
+        }
+    })
+}
+
+fn fold_field(value: &TokenStream, field: Field) -> Result<TokenStream> {
+    let mut params = Params::from_attrs(field.attrs, "traverse")?;
+    params.validate(&["skip", "with"])?;
+
+    if params
+        .param("skip")?
+        .map(Param::unit)
+        .transpose()?
+        .is_some()
+    {
+        return Ok(TokenStream::new());
+    }
+
+    let crate_name = resolve_crate_name();
+
+    match params.param("with")? {
+        None => Ok(quote! {
+            let #value = #crate_name::TraversableFold::traverse_fold(#value, folder)?;
+        }),
+        Some(traverse_fn) => {
+            let traverse_fn = traverse_fn.string_literal()?.parse::<Path>()?;
+            Ok(quote! {
+                let #value = #traverse_fn(#value, folder)?;
             })
         }
     }

--- a/traversable-derive/src/lib.rs
+++ b/traversable-derive/src/lib.rs
@@ -208,20 +208,16 @@ fn resolve_crate_name() -> Path {
     parse_quote!(::traversable)
 }
 
+fn take_unit_param(params: &mut Params, name: &str) -> Result<bool> {
+    Ok(params.param(name)?.map(Param::unit).transpose()?.is_some())
+}
+
 fn impl_traversable(input: DeriveInput, mutable: bool) -> Result<TokenStream> {
     let mut params = Params::from_attrs(input.attrs, "traverse")?;
     params.validate(&["skip_self", "skip_children"])?;
 
-    let skip_visit_self = params
-        .param("skip_self")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some();
-    let skip_children = params
-        .param("skip_children")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some();
+    let skip_visit_self = take_unit_param(&mut params, "skip_self")?;
+    let skip_children = take_unit_param(&mut params, "skip_children")?;
 
     let name = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -353,7 +349,7 @@ fn traverse_enum(e: DataEnum, mutable: bool) -> Result<TokenStream> {
 fn traverse_variant(v: Variant, mutable: bool) -> Result<TokenStream> {
     let mut params = Params::from_attrs(v.attrs, "traverse")?;
     params.validate(&["skip"])?;
-    if params.param("skip")?.map(Param::unit).is_some() {
+    if take_unit_param(&mut params, "skip")? {
         return Ok(TokenStream::new());
     }
     let name = v.ident;
@@ -390,7 +386,7 @@ fn destructure_fields(fields: Fields) -> Result<TokenStream> {
                 .map(|field| {
                     let mut params = Params::from_attrs(field.attrs, "traverse")?;
                     let field_name = field.ident.unwrap();
-                    Ok(if params.param("skip")?.map(Param::unit).is_some() {
+                    Ok(if take_unit_param(&mut params, "skip")? {
                         quote! { #field_name: _ }
                     } else {
                         field_name.into_token_stream()
@@ -408,7 +404,7 @@ fn destructure_fields(fields: Fields) -> Result<TokenStream> {
                 .enumerate()
                 .map(|(index, field)| {
                     let mut params = Params::from_attrs(field.attrs, "traverse")?;
-                    Ok(if params.param("skip")?.map(Param::unit).is_some() {
+                    Ok(if take_unit_param(&mut params, "skip")? {
                         quote! { _ }
                     } else {
                         Ident::new(&format!("i{index}",), Span::call_site()).into_token_stream()
@@ -427,7 +423,7 @@ fn traverse_field(value: &TokenStream, field: Field, mutable: bool) -> Result<To
     let mut params = Params::from_attrs(field.attrs, "traverse")?;
     params.validate(&["skip", "with"])?;
 
-    if params.param("skip")?.map(Param::unit).is_some() {
+    if take_unit_param(&mut params, "skip")? {
         return Ok(TokenStream::new());
     }
 
@@ -452,16 +448,8 @@ fn impl_traversable_fold(input: DeriveInput) -> Result<TokenStream> {
     let mut params = Params::from_attrs(input.attrs, "traverse")?;
     params.validate(&["skip_self", "skip_children"])?;
 
-    let skip_visit_self = params
-        .param("skip_self")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some();
-    let skip_children = params
-        .param("skip_children")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some();
+    let skip_visit_self = take_unit_param(&mut params, "skip_self")?;
+    let skip_children = take_unit_param(&mut params, "skip_children")?;
 
     let name = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -583,11 +571,7 @@ fn fold_enum(e: DataEnum) -> Result<TokenStream> {
 fn fold_variant(v: Variant) -> Result<TokenStream> {
     let mut params = Params::from_attrs(v.attrs, "traverse")?;
     params.validate(&["skip"])?;
-    let skip = params
-        .param("skip")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some();
+    let skip = take_unit_param(&mut params, "skip")?;
 
     let name = v.ident;
     Ok(match v.fields {
@@ -641,12 +625,7 @@ fn fold_field(value: &TokenStream, field: Field) -> Result<TokenStream> {
     let mut params = Params::from_attrs(field.attrs, "traverse")?;
     params.validate(&["skip", "with"])?;
 
-    if params
-        .param("skip")?
-        .map(Param::unit)
-        .transpose()?
-        .is_some()
-    {
+    if take_unit_param(&mut params, "skip")? {
         return Ok(TokenStream::new());
     }
 

--- a/traversable/src/function.rs
+++ b/traversable/src/function.rs
@@ -15,11 +15,8 @@
 //! Visitors from functions or closures.
 
 use core::any::Any;
-use core::any::TypeId;
 use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
 use core::ops::ControlFlow;
-use core::ptr;
 
 use crate::Folder;
 use crate::Visitor;
@@ -96,46 +93,38 @@ where
     type Break = B;
 
     fn enter<U: Any>(&mut self, this: U) -> ControlFlow<Self::Break, U> {
-        fold_if_type(this, &mut self.enter)
+        fold(this, &mut self.enter)
     }
 
     fn leave<U: Any>(&mut self, this: U) -> ControlFlow<Self::Break, U> {
-        fold_if_type(this, &mut self.leave)
+        fold(this, &mut self.leave)
     }
 }
 
-fn fold_if_type<T, U, B, F>(this: U, fold: &mut F) -> ControlFlow<B, U>
+fn fold<T, U, B, F>(this: U, fold: &mut F) -> ControlFlow<B, U>
 where
     T: Any,
     U: Any,
     F: FnMut(T) -> ControlFlow<B, T>,
 {
+    use core::any::TypeId;
+    use core::mem::ManuallyDrop;
+    use core::mem::transmute_copy;
+
     if TypeId::of::<T>() != TypeId::of::<U>() {
         return ControlFlow::Continue(this);
     }
 
-    let this = cast_between_equal_any_types::<U, T>(this);
-    match fold(this) {
-        ControlFlow::Continue(this) => {
-            ControlFlow::Continue(cast_between_equal_any_types::<T, U>(this))
-        }
-        ControlFlow::Break(break_value) => ControlFlow::Break(break_value),
-    }
-}
-
-fn cast_between_equal_any_types<From, To>(from: From) -> To
-where
-    From: Any,
-    To: Any,
-{
-    debug_assert_eq!(TypeId::of::<From>(), TypeId::of::<To>());
-
-    let from = ManuallyDrop::new(from);
-    // SAFETY: `fold_if_type` only calls this function after verifying that `From` and `To` have
-    // the same `TypeId`. `Any` is implemented only for `'static` concrete types, so equal TypeIds
-    // identify the same type. `ManuallyDrop` prevents dropping the source after ownership has been
-    // transferred through `ptr::read`.
-    unsafe { ptr::read((&*from as *const From).cast::<To>()) }
+    let this = unsafe {
+        let this = ManuallyDrop::new(this);
+        transmute_copy(&this)
+    };
+    let this = fold(this)?;
+    let this = unsafe {
+        let this = ManuallyDrop::new(this);
+        transmute_copy(&this)
+    };
+    ControlFlow::Continue(this)
 }
 
 type DefaultVisitFn<T, B> = fn(&T) -> ControlFlow<B>;

--- a/traversable/src/function.rs
+++ b/traversable/src/function.rs
@@ -452,10 +452,10 @@ where
 /// # Example
 ///
 /// ```rust
-/// # #[cfg(not(feature = "derive"))]
+/// # #[cfg(not(all(feature = "derive", feature = "std")))]
 /// # fn main() {}
 /// #
-/// # #[cfg(feature = "derive")]
+/// # #[cfg(all(feature = "derive", feature = "std"))]
 /// # fn main() {
 /// use core::ops::ControlFlow;
 ///

--- a/traversable/src/function.rs
+++ b/traversable/src/function.rs
@@ -15,14 +15,26 @@
 //! Visitors from functions or closures.
 
 use core::any::Any;
+use core::any::TypeId;
 use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::ControlFlow;
+use core::ptr;
 
+use crate::Folder;
 use crate::Visitor;
 use crate::VisitorMut;
 
 /// Type returned by `visitor` factories.
 pub struct FnVisitor<T, B, F1, F2> {
+    enter: F1,
+    leave: F2,
+    marker_type: PhantomData<T>,
+    marker_break: PhantomData<B>,
+}
+
+/// Type returned by `folder` factories.
+pub struct FnFolder<T, B, F1, F2> {
     enter: F1,
     leave: F2,
     marker_type: PhantomData<T>,
@@ -75,8 +87,60 @@ where
     }
 }
 
+impl<T, B, F1, F2> Folder for FnFolder<T, B, F1, F2>
+where
+    T: Any,
+    F1: FnMut(T) -> ControlFlow<B, T>,
+    F2: FnMut(T) -> ControlFlow<B, T>,
+{
+    type Break = B;
+
+    fn enter<U: Any>(&mut self, this: U) -> ControlFlow<Self::Break, U> {
+        fold_if_type(this, &mut self.enter)
+    }
+
+    fn leave<U: Any>(&mut self, this: U) -> ControlFlow<Self::Break, U> {
+        fold_if_type(this, &mut self.leave)
+    }
+}
+
+fn fold_if_type<T, U, B, F>(this: U, fold: &mut F) -> ControlFlow<B, U>
+where
+    T: Any,
+    U: Any,
+    F: FnMut(T) -> ControlFlow<B, T>,
+{
+    if TypeId::of::<T>() != TypeId::of::<U>() {
+        return ControlFlow::Continue(this);
+    }
+
+    let this = cast_between_equal_any_types::<U, T>(this);
+    match fold(this) {
+        ControlFlow::Continue(this) => {
+            ControlFlow::Continue(cast_between_equal_any_types::<T, U>(this))
+        }
+        ControlFlow::Break(break_value) => ControlFlow::Break(break_value),
+    }
+}
+
+fn cast_between_equal_any_types<From, To>(from: From) -> To
+where
+    From: Any,
+    To: Any,
+{
+    debug_assert_eq!(TypeId::of::<From>(), TypeId::of::<To>());
+
+    let from = ManuallyDrop::new(from);
+    // SAFETY: `fold_if_type` only calls this function after verifying that `From` and `To` have
+    // the same `TypeId`. `Any` is implemented only for `'static` concrete types, so equal TypeIds
+    // identify the same type. `ManuallyDrop` prevents dropping the source after ownership has been
+    // transferred through `ptr::read`.
+    unsafe { ptr::read((&*from as *const From).cast::<To>()) }
+}
+
 type DefaultVisitFn<T, B> = fn(&T) -> ControlFlow<B>;
 type DefaultVisitFnMut<T, B> = fn(&mut T) -> ControlFlow<B>;
+type DefaultFoldFn<T, B> = fn(T) -> ControlFlow<B, T>;
 
 /// Create a visitor that only visits items of a specific type from `enter` and `leave` closures.
 ///
@@ -374,6 +438,92 @@ where
 {
     FnVisitor {
         enter: |_| ControlFlow::Continue(()),
+        leave,
+        marker_type: PhantomData,
+        marker_break: PhantomData,
+    }
+}
+
+/// Create a folder that only folds items of a specific type from `enter` and `leave` closures.
+///
+/// This is a convenience function for creating simple owned transforms without defining a new
+/// struct and implementing the [`Folder`] trait manually.
+///
+/// # Example
+///
+/// ```rust
+/// # #[cfg(not(feature = "derive"))]
+/// # fn main() {}
+/// #
+/// # #[cfg(feature = "derive")]
+/// # fn main() {
+/// use core::ops::ControlFlow;
+///
+/// use traversable::TraversableFold;
+/// use traversable::function::folder_leave;
+///
+/// #[derive(TraversableFold)]
+/// enum Expr {
+///     Add(Box<Expr>, Box<Expr>),
+///     Literal(i32),
+/// }
+///
+/// fn simplify(expr: Expr) -> Expr {
+///     match expr {
+///         Expr::Add(left, right) => match (*left, *right) {
+///             (Expr::Literal(0), expr) | (expr, Expr::Literal(0)) => expr,
+///             (left, right) => Expr::Add(Box::new(left), Box::new(right)),
+///         },
+///         expr => expr,
+///     }
+/// }
+///
+/// let expr = Expr::Add(Box::new(Expr::Literal(0)), Box::new(Expr::Literal(1)));
+/// let mut folder = folder_leave::<Expr, (), _>(|expr| ControlFlow::Continue(simplify(expr)));
+/// let expr = match expr.traverse_fold(&mut folder) {
+///     ControlFlow::Continue(expr) => expr,
+///     ControlFlow::Break(()) => unreachable!(),
+/// };
+///
+/// assert!(matches!(expr, Expr::Literal(1)));
+/// # }
+/// ```
+pub fn folder<T, B, F1, F2>(enter: F1, leave: F2) -> FnFolder<T, B, F1, F2>
+where
+    T: Any,
+    F1: FnMut(T) -> ControlFlow<B, T>,
+    F2: FnMut(T) -> ControlFlow<B, T>,
+{
+    FnFolder {
+        enter,
+        leave,
+        marker_type: PhantomData,
+        marker_break: PhantomData,
+    }
+}
+
+/// Similar to [`folder`], but the closure will only be called on entering.
+pub fn folder_enter<T, B, F>(enter: F) -> FnFolder<T, B, F, DefaultFoldFn<T, B>>
+where
+    T: Any,
+    F: FnMut(T) -> ControlFlow<B, T>,
+{
+    FnFolder {
+        enter,
+        leave: ControlFlow::Continue,
+        marker_type: PhantomData,
+        marker_break: PhantomData,
+    }
+}
+
+/// Similar to [`folder`], but the closure will only be called on leaving.
+pub fn folder_leave<T, B, F>(leave: F) -> FnFolder<T, B, DefaultFoldFn<T, B>, F>
+where
+    T: Any,
+    F: FnMut(T) -> ControlFlow<B, T>,
+{
+    FnFolder {
+        enter: ControlFlow::Continue,
         leave,
         marker_type: PhantomData,
         marker_break: PhantomData,

--- a/traversable/src/function.rs
+++ b/traversable/src/function.rs
@@ -115,11 +115,17 @@ where
         return ControlFlow::Continue(this);
     }
 
+    // SAFETY: The `TypeId` check above proves that `T` and `U` are the same concrete `'static`
+    // type. `ManuallyDrop` prevents the original `U` value from being dropped after its bits are
+    // copied into the owned `T` value that is passed to the typed closure.
     let this = unsafe {
         let this = ManuallyDrop::new(this);
         transmute_copy(&this)
     };
     let this = fold(this)?;
+    // SAFETY: The same `TypeId` equality still proves that `T` and `U` are the same concrete
+    // `'static` type. `ManuallyDrop` prevents the closure result from being dropped after its bits
+    // are copied back into the caller's expected `U` type.
     let this = unsafe {
         let this = ManuallyDrop::new(this);
         transmute_copy(&this)

--- a/traversable/src/impls/mod.rs
+++ b/traversable/src/impls/mod.rs
@@ -28,6 +28,13 @@ macro_rules! blank_traverse_impl {
                 ControlFlow::Continue(())
             }
         }
+
+        impl TraversableFold for $type {
+            #[inline]
+            fn traverse_fold<V: Folder>(self, _folder: &mut V) -> ControlFlow<V::Break, Self> {
+                ControlFlow::Continue(self)
+            }
+        }
     };
 }
 
@@ -47,6 +54,14 @@ macro_rules! trivial_traverse_impl {
                 visitor.enter_mut(self)?;
                 visitor.leave_mut(self)?;
                 ControlFlow::Continue(())
+            }
+        }
+
+        impl TraversableFold for $type {
+            fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+                let this = folder.enter(self)?;
+                let this = folder.leave(this)?;
+                ControlFlow::Continue(this)
             }
         }
     };

--- a/traversable/src/impls/ordered_float_5.rs
+++ b/traversable/src/impls/ordered_float_5.rs
@@ -16,7 +16,9 @@ use core::ops::ControlFlow;
 
 use ordered_float_5::OrderedFloat;
 
+use crate::Folder;
 use crate::Traversable;
+use crate::TraversableFold;
 use crate::TraversableMut;
 use crate::Visitor;
 use crate::VisitorMut;
@@ -34,5 +36,13 @@ impl<T: 'static> TraversableMut for OrderedFloat<T> {
         visitor.enter_mut(self)?;
         visitor.leave_mut(self)?;
         ControlFlow::Continue(())
+    }
+}
+
+impl<T: 'static> TraversableFold for OrderedFloat<T> {
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let this = folder.enter(self)?;
+        let this = folder.leave(this)?;
+        ControlFlow::Continue(this)
     }
 }

--- a/traversable/src/impls/std_container.rs
+++ b/traversable/src/impls/std_container.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::RwLock;
 
+use crate::Folder;
 use crate::Traversable;
+use crate::TraversableFold;
 use crate::TraversableMut;
 use crate::Visitor;
 use crate::VisitorMut;
@@ -56,6 +58,37 @@ impl<TK, TV: TraversableMut> DerefAndTraverseMut for (TK, &mut TV) {
     fn deref_and_traverse_mut<V: VisitorMut>(self, visitor: &mut V) -> ControlFlow<V::Break> {
         self.1.traverse_mut(visitor)
     }
+}
+
+fn traverse_fold_items<T, V, I, C>(items: I, folder: &mut V) -> ControlFlow<V::Break, C>
+where
+    T: TraversableFold,
+    V: Folder,
+    I: IntoIterator<Item = T>,
+    C: FromIterator<T>,
+{
+    let mut folded = std::vec::Vec::new();
+    for item in items {
+        folded.push(item.traverse_fold(folder)?);
+    }
+    ControlFlow::Continue(folded.into_iter().collect())
+}
+
+fn traverse_fold_pairs<K, Value, V, I, C>(items: I, folder: &mut V) -> ControlFlow<V::Break, C>
+where
+    K: TraversableFold,
+    Value: TraversableFold,
+    V: Folder,
+    I: IntoIterator<Item = (K, Value)>,
+    C: FromIterator<(K, Value)>,
+{
+    let mut folded = std::vec::Vec::new();
+    for (key, value) in items {
+        let key = key.traverse_fold(folder)?;
+        let value = value.traverse_fold(folder)?;
+        folded.push((key, value));
+    }
+    ControlFlow::Continue(folded.into_iter().collect())
 }
 
 macro_rules! impl_drive_for_into_iterator {
@@ -105,6 +138,80 @@ impl_drive_for_into_iterator! { std::collections::HashMap<T, U> ; T, U }
 impl_drive_for_into_iterator! { Option<T> ; T }
 impl_drive_for_into_iterator! { Result<T, U> ; T, U }
 
+macro_rules! impl_fold_for_collection {
+    ( $type:ty ; $($generics:tt)+ ) => {
+        impl< $($generics)+ > TraversableFold for $type
+        where
+            $type: 'static + IntoIterator + FromIterator<<$type as IntoIterator>::Item>,
+            <$type as IntoIterator>::Item: TraversableFold,
+        {
+            fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+                traverse_fold_items(self, folder)
+            }
+        }
+    };
+}
+
+macro_rules! impl_fold_for_map {
+    ( $type:ty ; $($generics:tt)+ ) => {
+        impl< $($generics)+ > TraversableFold for $type
+        where
+            $type: 'static + IntoIterator<Item = (T, U)> + FromIterator<(T, U)>,
+            T: TraversableFold,
+            U: TraversableFold,
+        {
+            fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+                traverse_fold_pairs(self, folder)
+            }
+        }
+    };
+}
+
+impl<T: TraversableFold, const N: usize> TraversableFold for [T; N] {
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let mut folded = std::vec::Vec::with_capacity(N);
+        for item in self {
+            folded.push(item.traverse_fold(folder)?);
+        }
+        let folded = match folded.try_into() {
+            Ok(folded) => folded,
+            Err(_) => unreachable!("folded array length must match the input array length"),
+        };
+        ControlFlow::Continue(folded)
+    }
+}
+
+impl_fold_for_collection! { std::vec::Vec<T> ; T }
+impl_fold_for_collection! { std::collections::BTreeSet<T> ; T }
+impl_fold_for_collection! { std::collections::BinaryHeap<T> ; T }
+impl_fold_for_collection! { std::collections::HashSet<T> ; T }
+impl_fold_for_collection! { std::collections::LinkedList<T> ; T }
+impl_fold_for_collection! { std::collections::VecDeque<T> ; T }
+impl_fold_for_map! { std::collections::BTreeMap<T, U> ; T, U }
+impl_fold_for_map! { std::collections::HashMap<T, U> ; T, U }
+
+impl<T: TraversableFold> TraversableFold for Option<T> {
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        match self {
+            Some(item) => ControlFlow::Continue(Some(item.traverse_fold(folder)?)),
+            None => ControlFlow::Continue(None),
+        }
+    }
+}
+
+impl<T, U> TraversableFold for Result<T, U>
+where
+    T: TraversableFold,
+    U: 'static,
+{
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        match self {
+            Ok(item) => ControlFlow::Continue(Ok(item.traverse_fold(folder)?)),
+            Err(error) => ControlFlow::Continue(Err(error)),
+        }
+    }
+}
+
 impl<T: Traversable> Traversable for Box<T> {
     fn traverse<V: Visitor>(&self, visitor: &mut V) -> ControlFlow<V::Break> {
         (**self).traverse(visitor)
@@ -114,6 +221,12 @@ impl<T: Traversable> Traversable for Box<T> {
 impl<T: TraversableMut> TraversableMut for Box<T> {
     fn traverse_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         (**self).traverse_mut(visitor)
+    }
+}
+
+impl<T: TraversableFold> TraversableFold for Box<T> {
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        ControlFlow::Continue(Box::new((*self).traverse_fold(folder)?))
     }
 }
 
@@ -143,6 +256,17 @@ where
     }
 }
 
+impl<T> TraversableFold for Mutex<T>
+where
+    T: TraversableFold,
+{
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let item = self.into_inner().unwrap();
+        let item = item.traverse_fold(folder)?;
+        ControlFlow::Continue(Mutex::new(item))
+    }
+}
+
 impl<T> Traversable for RwLock<T>
 where
     T: Traversable,
@@ -160,6 +284,17 @@ where
     fn traverse_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         let lock = self.get_mut().unwrap();
         lock.traverse_mut(visitor)
+    }
+}
+
+impl<T> TraversableFold for RwLock<T>
+where
+    T: TraversableFold,
+{
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let item = self.into_inner().unwrap();
+        let item = item.traverse_fold(folder)?;
+        ControlFlow::Continue(RwLock::new(item))
     }
 }
 
@@ -198,5 +333,15 @@ where
 {
     fn traverse_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break> {
         self.get_mut().traverse_mut(visitor)
+    }
+}
+
+impl<T> TraversableFold for Cell<T>
+where
+    T: TraversableFold,
+{
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+        let item = self.into_inner().traverse_fold(folder)?;
+        ControlFlow::Continue(Cell::new(item))
     }
 }

--- a/traversable/src/impls/std_primary.rs
+++ b/traversable/src/impls/std_primary.rs
@@ -15,7 +15,9 @@
 use core::ops::ControlFlow;
 use std::string::String;
 
+use crate::Folder;
 use crate::Traversable;
+use crate::TraversableFold;
 use crate::TraversableMut;
 use crate::Visitor;
 use crate::VisitorMut;

--- a/traversable/src/impls/trivial.rs
+++ b/traversable/src/impls/trivial.rs
@@ -14,7 +14,9 @@
 
 use core::ops::ControlFlow;
 
+use crate::Folder;
 use crate::Traversable;
+use crate::TraversableFold;
 use crate::TraversableMut;
 use crate::Visitor;
 use crate::VisitorMut;

--- a/traversable/src/impls/tuple.rs
+++ b/traversable/src/impls/tuple.rs
@@ -14,7 +14,9 @@
 
 use core::ops::ControlFlow;
 
+use crate::Folder;
 use crate::Traversable;
+use crate::TraversableFold;
 use crate::TraversableMut;
 use crate::Visitor;
 use crate::VisitorMut;
@@ -47,6 +49,22 @@ macro_rules! tuple_impl {
                         self.$field.traverse_mut(visitor)?;
                     )+
                     ControlFlow::Continue(())
+                }
+            }
+
+            impl<$( $type ),+> TraversableFold for ($($type,)+)
+            where
+                $(
+                    $type: TraversableFold
+                ),+
+            {
+                #[allow(non_snake_case)]
+                fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self> {
+                    let ($($type,)+) = self;
+                    $(
+                        let $type = $type.traverse_fold(folder)?;
+                    )+
+                    ControlFlow::Continue(($($type,)+))
                 }
             }
         )+

--- a/traversable/src/lib.rs
+++ b/traversable/src/lib.rs
@@ -16,9 +16,9 @@
 //!
 //! A visitor pattern implementation for traversing data structures.
 //!
-//! This crate provides [`Traversable`] and [`TraversableMut`] traits for types that can be
-//! traversed, as well as [`Visitor`] and [`VisitorMut`] traits for types that perform the
-//! traversal.
+//! This crate provides [`Traversable`], [`TraversableMut`], and [`TraversableFold`] traits for
+//! types that can be traversed, as well as [`Visitor`], [`VisitorMut`], and [`Folder`] traits for
+//! types that perform the traversal.
 //!
 //! It is designed to be flexible and efficient, allowing for deep traversal of complex data
 //! structures.
@@ -29,7 +29,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! traversable = { version = "0.2", features = ["derive", "std"] }
+//! traversable = { version = "0.3", features = ["derive", "std"] }
 //! ```
 //!
 //! Define your data structures and derive [`Traversable`]:
@@ -119,7 +119,8 @@
 //!
 //! ## Features
 //!
-//! * `derive`: Enables procedural macros `#[derive(Traversable)]` and `#[derive(TraversableMut)]`.
+//! * `derive`: Enables procedural macros `#[derive(Traversable)]`, `#[derive(TraversableMut)]`,
+//!   and `#[derive(TraversableFold)]`.
 //! * `std`: Enables support for standard library types (e.g., `Vec`, `HashMap`, `Box`).
 //! * `traverse-trivial`: Enables traversal for primitive types (`u8`, `i32`, `bool`, etc.). By
 //!   default, these are ignored.
@@ -139,6 +140,9 @@ use core::ops::ControlFlow;
 #[cfg(feature = "derive")]
 /// See [`Traversable`].
 pub use traversable_derive::Traversable;
+#[cfg(feature = "derive")]
+/// See [`TraversableFold`].
+pub use traversable_derive::TraversableFold;
 #[cfg(feature = "derive")]
 /// See [`TraversableMut`].
 pub use traversable_derive::TraversableMut;
@@ -248,6 +252,37 @@ pub trait VisitorMut {
     fn leave_mut(&mut self, this: &mut dyn core::any::Any) -> ControlFlow<Self::Break> {
         let _ = this;
         ControlFlow::Continue(())
+    }
+}
+
+/// A folder that can transform an owned data structure while traversing it.
+///
+/// Implement this trait to define custom logic that receives owned nodes and returns the node that
+/// should continue through traversal. This is useful for bottom-up rewrites such as simplifying an
+/// expression tree without using temporary replacement values.
+///
+/// [`TraversableFold`] calls [`Folder::enter`] before folding children and [`Folder::leave`] after
+/// folding children. The default implementation returns each node unchanged.
+///
+/// You can also use [`folder`] to create a folder from closures.
+///
+/// [`folder`]: function::folder
+pub trait Folder {
+    /// The type that can be used to break traversal early.
+    type Break;
+
+    /// Called when the folder is entering an owned node.
+    ///
+    /// Default implementation returns the node unchanged and continues traversal.
+    fn enter<T: core::any::Any>(&mut self, this: T) -> ControlFlow<Self::Break, T> {
+        ControlFlow::Continue(this)
+    }
+
+    /// Called when the folder is leaving an owned node.
+    ///
+    /// Default implementation returns the node unchanged and continues traversal.
+    fn leave<T: core::any::Any>(&mut self, this: T) -> ControlFlow<Self::Break, T> {
+        ControlFlow::Continue(this)
     }
 }
 
@@ -407,4 +442,56 @@ pub trait Traversable: core::any::Any {
 pub trait TraversableMut: core::any::Any {
     /// Traverse the mutable data structure with the given visitor.
     fn traverse_mut<V: VisitorMut>(&mut self, visitor: &mut V) -> ControlFlow<V::Break>;
+}
+
+/// A trait for types that can be traversed and transformed by a folder.
+///
+/// This trait consumes `self`, folds its children, and returns the rebuilt value. It is intended for
+/// owned transformations where a node may need to be replaced by another value of the same type.
+///
+/// # Deriving `TraversableFold`
+///
+/// The easiest way to implement `TraversableFold` is to use the derive macro.
+///
+/// ```rust
+/// # #[cfg(not(feature = "derive"))]
+/// # fn main() {}
+/// #
+/// # #[cfg(feature = "derive")]
+/// # fn main() {
+/// use traversable::TraversableFold;
+///
+/// #[derive(TraversableFold)]
+/// struct MyStruct {
+///     data: u64,
+///     #[traverse(skip)]
+///     hidden: String,
+/// }
+/// # }
+/// ```
+///
+/// # Attributes
+///
+/// The derive macro supports the following attributes on structs and enums:
+///
+/// * `#[traverse(skip_self)]`: Skips calling the folder for the annotated type while still folding
+///   its children.
+/// * `#[traverse(skip_children)]`: Calls the folder for the annotated type without folding its
+///   children.
+///
+/// The derive macro supports the following attributes on fields and variants:
+///
+/// * `#[traverse(skip)]`: Skips folding into the annotated field or variant.
+/// * `#[traverse(with = "function_name")]`: Uses a custom function to fold the field.
+///
+/// ## Custom Fold Function
+///
+/// When using `#[traverse(with = "path::to::func")]`, the function must have the signature:
+///
+/// ```rust,ignore
+/// fn func<V: Folder>(item: ItemType, folder: &mut V) -> ControlFlow<V::Break, ItemType>
+/// ```
+pub trait TraversableFold: core::any::Any + Sized {
+    /// Traverse and transform the data structure with the given folder.
+    fn traverse_fold<V: Folder>(self, folder: &mut V) -> ControlFlow<V::Break, Self>;
 }

--- a/traversable/src/lib.rs
+++ b/traversable/src/lib.rs
@@ -119,8 +119,8 @@
 //!
 //! ## Features
 //!
-//! * `derive`: Enables procedural macros `#[derive(Traversable)]`, `#[derive(TraversableMut)]`,
-//!   and `#[derive(TraversableFold)]`.
+//! * `derive`: Enables procedural macros `#[derive(Traversable)]`, `#[derive(TraversableMut)]`, and
+//!   `#[derive(TraversableFold)]`.
 //! * `std`: Enables support for standard library types (e.g., `Vec`, `HashMap`, `Box`).
 //! * `traverse-trivial`: Enables traversal for primitive types (`u8`, `i32`, `bool`, etc.). By
 //!   default, these are ignored.
@@ -446,8 +446,9 @@ pub trait TraversableMut: core::any::Any {
 
 /// A trait for types that can be traversed and transformed by a folder.
 ///
-/// This trait consumes `self`, folds its children, and returns the rebuilt value. It is intended for
-/// owned transformations where a node may need to be replaced by another value of the same type.
+/// This trait consumes `self`, folds its children, and returns the rebuilt value. It is intended
+/// for owned transformations where a node may need to be replaced by another value of the same
+/// type.
 ///
 /// # Deriving `TraversableFold`
 ///

--- a/traversable/tests/test_folder.rs
+++ b/traversable/tests/test_folder.rs
@@ -1,0 +1,251 @@
+// Copyright 2025 FastLabs Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(all(feature = "std", feature = "derive"))]
+
+use core::any::Any;
+use core::any::TypeId;
+use core::ops::ControlFlow;
+
+use traversable::Folder;
+use traversable::TraversableFold;
+use traversable::function::folder_leave;
+
+fn into_continue<T>(flow: ControlFlow<(), T>) -> T {
+    match flow {
+        ControlFlow::Continue(value) => value,
+        ControlFlow::Break(()) => unreachable!(),
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, TraversableFold)]
+enum Expr {
+    Add(Box<Expr>, Box<Expr>),
+    Literal(i32),
+}
+
+fn simplify(expr: Expr) -> Expr {
+    match expr {
+        Expr::Add(left, right) => match (*left, *right) {
+            (Expr::Literal(0), expr) | (expr, Expr::Literal(0)) => expr,
+            (left, right) => Expr::Add(Box::new(left), Box::new(right)),
+        },
+        expr => expr,
+    }
+}
+
+#[test]
+fn folder_leave_rewrites_bottom_up() {
+    let expr = Expr::Add(
+        Box::new(Expr::Add(
+            Box::new(Expr::Literal(0)),
+            Box::new(Expr::Literal(1)),
+        )),
+        Box::new(Expr::Literal(0)),
+    );
+
+    let mut folder = folder_leave::<Expr, (), _>(|expr| ControlFlow::Continue(simplify(expr)));
+    let expr = into_continue(expr.traverse_fold(&mut folder));
+
+    assert_eq!(expr, Expr::Literal(1));
+}
+
+#[derive(Debug, PartialEq, Eq, TraversableFold)]
+struct Child {
+    value: u64,
+}
+
+#[derive(TraversableFold)]
+struct Pair {
+    #[traverse(with = "fold_and_double")]
+    folded: Child,
+    #[traverse(skip)]
+    skipped: Child,
+}
+
+fn fold_and_double<V: Folder>(child: Child, folder: &mut V) -> ControlFlow<V::Break, Child> {
+    let mut child = child.traverse_fold(folder)?;
+    child.value *= 2;
+    ControlFlow::Continue(child)
+}
+
+#[test]
+fn field_attributes_control_fold_behavior() {
+    let pair = Pair {
+        folded: Child { value: 1 },
+        skipped: Child { value: 10 },
+    };
+
+    let mut folder = folder_leave::<Child, (), _>(|mut child| {
+        child.value += 1;
+        ControlFlow::Continue(child)
+    });
+    let pair = into_continue(pair.traverse_fold(&mut folder));
+
+    assert_eq!(pair.folded, Child { value: 4 });
+    assert_eq!(pair.skipped, Child { value: 10 });
+}
+
+#[test]
+fn std_containers_fold_owned_items() {
+    let mut folder = folder_leave::<Child, (), _>(|mut child| {
+        child.value += 1;
+        ControlFlow::Continue(child)
+    });
+
+    let values = vec![Child { value: 1 }, Child { value: 2 }];
+    let values = into_continue(values.traverse_fold(&mut folder));
+
+    assert_eq!(values, vec![Child { value: 2 }, Child { value: 3 }]);
+
+    let value = Some(Child { value: 4 });
+    let value = into_continue(value.traverse_fold(&mut folder));
+
+    assert_eq!(value, Some(Child { value: 5 }));
+
+    let value = Ok::<_, Child>(Child { value: 6 });
+    let value = into_continue(value.traverse_fold(&mut folder));
+
+    assert_eq!(value, Ok(Child { value: 7 }));
+}
+
+#[derive(TraversableFold)]
+struct Parent {
+    child: Child,
+}
+
+#[derive(TraversableFold)]
+#[traverse(skip_self)]
+struct SkipSelfParent {
+    child: Child,
+}
+
+#[derive(TraversableFold)]
+#[traverse(skip_children)]
+#[allow(dead_code)]
+struct SkipChildrenParent {
+    child: Child,
+}
+
+#[derive(TraversableFold)]
+#[traverse(skip_self, skip_children)]
+#[allow(dead_code)]
+struct SkipSelfAndChildrenParent {
+    child: Child,
+}
+
+#[derive(Default)]
+struct Counts {
+    parent_enter: usize,
+    parent_leave: usize,
+    child_enter: usize,
+    child_leave: usize,
+    skip_self_parent_enter: usize,
+    skip_self_parent_leave: usize,
+    skip_children_parent_enter: usize,
+    skip_children_parent_leave: usize,
+    skip_self_and_children_parent_enter: usize,
+    skip_self_and_children_parent_leave: usize,
+}
+
+impl Folder for Counts {
+    type Break = ();
+
+    fn enter<T: Any>(&mut self, this: T) -> ControlFlow<Self::Break, T> {
+        if TypeId::of::<T>() == TypeId::of::<Parent>() {
+            self.parent_enter += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<Child>() {
+            self.child_enter += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipSelfParent>() {
+            self.skip_self_parent_enter += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipChildrenParent>() {
+            self.skip_children_parent_enter += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipSelfAndChildrenParent>() {
+            self.skip_self_and_children_parent_enter += 1;
+        }
+
+        ControlFlow::Continue(this)
+    }
+
+    fn leave<T: Any>(&mut self, this: T) -> ControlFlow<Self::Break, T> {
+        if TypeId::of::<T>() == TypeId::of::<Parent>() {
+            self.parent_leave += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<Child>() {
+            self.child_leave += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipSelfParent>() {
+            self.skip_self_parent_leave += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipChildrenParent>() {
+            self.skip_children_parent_leave += 1;
+        } else if TypeId::of::<T>() == TypeId::of::<SkipSelfAndChildrenParent>() {
+            self.skip_self_and_children_parent_leave += 1;
+        }
+
+        ControlFlow::Continue(this)
+    }
+}
+
+#[test]
+fn type_level_attributes_control_fold_behavior() {
+    let mut counts = Counts::default();
+    let parent = Parent {
+        child: Child { value: 1 },
+    };
+
+    let result = parent.traverse_fold(&mut counts);
+
+    assert!(result.is_continue());
+    assert_eq!(counts.parent_enter, 1);
+    assert_eq!(counts.parent_leave, 1);
+    assert_eq!(counts.child_enter, 1);
+    assert_eq!(counts.child_leave, 1);
+
+    let mut counts = Counts::default();
+    let skip_self = SkipSelfParent {
+        child: Child { value: 1 },
+    };
+
+    let result = skip_self.traverse_fold(&mut counts);
+
+    assert!(result.is_continue());
+    assert_eq!(counts.skip_self_parent_enter, 0);
+    assert_eq!(counts.skip_self_parent_leave, 0);
+    assert_eq!(counts.child_enter, 1);
+    assert_eq!(counts.child_leave, 1);
+
+    let mut counts = Counts::default();
+    let skip_children = SkipChildrenParent {
+        child: Child { value: 1 },
+    };
+
+    let result = skip_children.traverse_fold(&mut counts);
+
+    assert!(result.is_continue());
+    assert_eq!(counts.skip_children_parent_enter, 1);
+    assert_eq!(counts.skip_children_parent_leave, 1);
+    assert_eq!(counts.child_enter, 0);
+    assert_eq!(counts.child_leave, 0);
+
+    let mut counts = Counts::default();
+    let skip_self_and_children = SkipSelfAndChildrenParent {
+        child: Child { value: 1 },
+    };
+
+    let result = skip_self_and_children.traverse_fold(&mut counts);
+
+    assert!(result.is_continue());
+    assert_eq!(counts.skip_self_and_children_parent_enter, 0);
+    assert_eq!(counts.skip_self_and_children_parent_leave, 0);
+    assert_eq!(counts.child_enter, 0);
+    assert_eq!(counts.child_leave, 0);
+}


### PR DESCRIPTION
## Summary
- add TraversableFold and Folder for owned bottom-up traversal and transformation
- add derive support for #[derive(TraversableFold)] with existing traverse attributes
- add folder helper closures and fold impls for core/std container types

## Verification
- cargo test --workspace
- cargo test --workspace --all-features
- cargo clippy --workspace --all-features --all-targets

Refs #19