### PR TITLE
chore: upgrade syn to 3.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -288,7 +288,7 @@ checksum = "4825bd5b513e9bc047a10ffc1680d1203ef548bdccd633d633a15630f01d126f"
 dependencies = [
  "proc-macro-error2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -302,6 +302,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -323,7 +334,7 @@ version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/traversable-derive/Cargo.toml
+++ b/traversable-derive/Cargo.toml
@@ -33,7 +33,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { version = "1.0.101" }
 quote = { version = "1.0.41" }
-syn = { version = "2.0.106", features = ["extra-traits"] }
+syn = { version = "3.0.3", features = ["extra-traits"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- upgrade traversable-derive from syn 2.0.106 to 3.0.3
- update Cargo.lock while retaining syn 2.0.106 for transitive dependencies
- keep the existing derive implementation unchanged because it is compatible with syn 3

## Testing

- cargo x lint
- cargo x test --no-capture
- cargo +1.85.0 test --workspace --all-features --locked --no-fail-fast