### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           components: rustfmt,clippy
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye@7.0.0
+          tool: typos-cli,taplo-cli,hawkeye
       - run: cargo x lint
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           components: rustfmt,clippy
       - uses: taiki-e/install-action@v2
         with:
-          tool: typos-cli,taplo-cli,hawkeye
+          tool: typos-cli,taplo-cli,hawkeye@7.0.0
       - run: cargo x lint
 
   test:

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
 includes = ['**/*.proto', '**/*.rs', '**/*.yml', '**/*.yaml', '**/*.toml']
 
-[properties]
-copyrightOwner = "FastLabs Developers"
-inceptionYear = 2025
+[props]
+copyright_owner = "FastLabs Developers"
+inception_year = 2025

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -178,10 +178,10 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
 }
 
 fn make_hawkeye_cmd(fix: bool) -> StdCommand {
-    ensure_installed("hawkeye", "hawkeye");
+    ensure_installed("hawkeye", "hawkeye@7.0.0");
     let mut cmd = find_command("hawkeye");
     if fix {
-        cmd.args(["format", "--fail-if-updated=false"]);
+        cmd.args(["format"]);
     } else {
         cmd.args(["check"]);
     }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -178,7 +178,7 @@ fn make_clippy_cmd(fix: bool) -> StdCommand {
 }
 
 fn make_hawkeye_cmd(fix: bool) -> StdCommand {
-    ensure_installed("hawkeye", "hawkeye@7.0.0");
+    ensure_installed("hawkeye", "hawkeye");
     let mut cmd = find_command("hawkeye");
     if fix {
         cmd.args(["format"]);


### PR DESCRIPTION
## Summary

- migrate licenserc.toml to the HawkEye v7 schema
- install the latest HawkEye in CI and repository tooling
- remove the v6-only format failure option